### PR TITLE
add interface rename and inject client chain element

### DIFF
--- a/pkg/kernel/networkservice/inject/client.go
+++ b/pkg/kernel/networkservice/inject/client.go
@@ -1,9 +1,18 @@
-// Copyright (C) 2021, Nordix Foundation
+// Copyright (c) 2020 Nordix Foundation.
 //
-// All rights reserved. This program and the accompanying materials
-// are made available under the terms of the Apache License, Version 2.0
-// which accompanies this distribution, and is available at
-// http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package inject
 

--- a/pkg/kernel/networkservice/inject/client.go
+++ b/pkg/kernel/networkservice/inject/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Nordix Foundation.
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -44,6 +44,9 @@ func (c *injectClient) Request(ctx context.Context, request *networkservice.Netw
 		return nil, err
 	}
 	if err := move(logger, conn, false); err != nil {
+		if _, closeErr := next.Client(ctx).Close(ctx, conn, opts...); closeErr != nil {
+			logger.Errorf("failed to close failed connection: %s %s", conn.GetId(), closeErr.Error())
+		}
 		return nil, err
 	}
 	return conn, nil

--- a/pkg/kernel/networkservice/inject/client.go
+++ b/pkg/kernel/networkservice/inject/client.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2021, Nordix Foundation
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Apache License, Version 2.0
+// which accompanies this distribution, and is available at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package inject
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+type injectClient struct{}
+
+// NewClient - returns a new networkservice.NetworkServiceClient that moves given network
+// interface into the Endpoint's pod network namespace on Request and back to Forwarder's
+// network namespace on Close
+func NewClient() networkservice.NetworkServiceClient {
+	return &injectClient{}
+}
+
+func (c *injectClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest,
+	opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	logger := log.FromContext(ctx).WithField("injectClient", "Request")
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := move(logger, conn, false); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *injectClient) Close(ctx context.Context, conn *networkservice.Connection,
+	opts ...grpc.CallOption) (*empty.Empty, error) {
+	logger := log.FromContext(ctx).WithField("injectClient", "Close")
+
+	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
+
+	injectErr := move(logger, conn, true)
+
+	if err != nil && injectErr != nil {
+		return nil, errors.Wrap(err, injectErr.Error())
+	}
+	if injectErr != nil {
+		return nil, injectErr
+	}
+	return rv, err
+}

--- a/pkg/kernel/networkservice/inject/common.go
+++ b/pkg/kernel/networkservice/inject/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Nordix Foundation.
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -61,7 +61,7 @@ func move(logger log.Logger, conn *networkservice.Connection, isMoveBack bool) e
 	}
 	defer func() { _ = targetNetNS.Close() }()
 
-	ifName := mech.GetInterfaceName(conn)
+	ifName := mech.GetInterfaceName()
 	if !isMoveBack {
 		err = moveInterfaceToAnotherNamespace(ifName, curNetNS, curNetNS, targetNetNS)
 	} else {

--- a/pkg/kernel/networkservice/inject/common.go
+++ b/pkg/kernel/networkservice/inject/common.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2021, Nordix Foundation
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Apache License, Version 2.0
+// which accompanies this distribution, and is available at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package inject
+
+import (
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/tools/nshandle"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+func moveInterfaceToAnotherNamespace(ifName string, curNetNS, fromNetNS, toNetNS netns.NsHandle) error {
+	return nshandle.RunIn(curNetNS, fromNetNS, func() error {
+		link, err := netlink.LinkByName(ifName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get net interface: %v", ifName)
+		}
+
+		if err := netlink.LinkSetNsFd(link, int(toNetNS)); err != nil {
+			return errors.Wrapf(err, "failed to move net interface to net NS: %v %v", ifName, toNetNS)
+		}
+
+		return nil
+	})
+}
+
+func move(logger log.Logger, conn *networkservice.Connection, isMoveBack bool) error {
+	mech := kernel.ToMechanism(conn.GetMechanism())
+	if mech == nil {
+		return nil
+	}
+
+	curNetNS, err := nshandle.Current()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = curNetNS.Close() }()
+
+	var targetNetNS netns.NsHandle
+	targetNetNS, err = nshandle.FromURL(mech.GetNetNSURL())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = targetNetNS.Close() }()
+
+	ifName := mech.GetInterfaceName(conn)
+	if !isMoveBack {
+		err = moveInterfaceToAnotherNamespace(ifName, curNetNS, curNetNS, targetNetNS)
+	} else {
+		err = moveInterfaceToAnotherNamespace(ifName, curNetNS, targetNetNS, curNetNS)
+	}
+	if err != nil {
+		logger.Warnf("failed to move network interface %s into the target namespace for connection %s", ifName, conn.GetId())
+		return err
+	}
+	logger.Infof("moved network interface %s into the target namespace for connection %s", ifName, conn.GetId())
+	return nil
+}

--- a/pkg/kernel/networkservice/inject/common.go
+++ b/pkg/kernel/networkservice/inject/common.go
@@ -1,20 +1,30 @@
-// Copyright (C) 2021, Nordix Foundation
+// Copyright (c) 2020 Nordix Foundation.
 //
-// All rights reserved. This program and the accompanying materials
-// are made available under the terms of the Apache License, Version 2.0
-// which accompanies this distribution, and is available at
-// http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package inject
 
 import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
-	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/tools/nshandle"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/tools/nshandle"
 )
 
 func moveInterfaceToAnotherNamespace(ifName string, curNetNS, fromNetNS, toNetNS netns.NsHandle) error {

--- a/pkg/kernel/networkservice/inject/server.go
+++ b/pkg/kernel/networkservice/inject/server.go
@@ -70,7 +70,10 @@ func (s *injectServer) Request(ctx context.Context, request *networkservice.Netw
 
 	conn, err := next.Server(ctx).Request(ctx, request)
 	if err != nil {
-		move(logger, request.GetConnection(), true)
+		err = move(logger, request.GetConnection(), true)
+		if err != nil {
+			logger.Warnf("server request failed, failed to move back the interface: %v", err)
+		}
 	}
 	return conn, err
 }

--- a/pkg/kernel/networkservice/inject/server.go
+++ b/pkg/kernel/networkservice/inject/server.go
@@ -45,26 +45,7 @@ func (s *injectServer) Request(ctx context.Context, request *networkservice.Netw
 		return next.Server(ctx).Request(ctx, request)
 	}
 
-<<<<<<< HEAD
-	curNetNS, err := nshandle.Current()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = curNetNS.Close() }()
-
-	var clientNetNS netns.NsHandle
-	clientNetNS, err = nshandle.FromURL(mech.GetNetNSURL())
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = clientNetNS.Close() }()
-
-	ifName := mech.GetInterfaceName()
-	err = moveInterfaceToAnotherNamespace(ifName, curNetNS, curNetNS, clientNetNS)
-	if err != nil {
-=======
 	if err := move(logger, request.GetConnection(), false); err != nil {
->>>>>>> 312f205 (add interface rename and inject client chain element)
 		return nil, err
 	}
 
@@ -85,28 +66,6 @@ func (s *injectServer) Close(ctx context.Context, conn *networkservice.Connectio
 
 	injectErr := move(logger, conn, true)
 
-<<<<<<< HEAD
-		if curNetNS, injectErr = nshandle.Current(); injectErr != nil {
-			goto exit
-		}
-		defer func() { _ = curNetNS.Close() }()
-
-		if clientNetNS, injectErr = nshandle.FromURL(mech.GetNetNSURL()); injectErr != nil {
-			goto exit
-		}
-		defer func() { _ = clientNetNS.Close() }()
-
-		ifName = mech.GetInterfaceName()
-		if injectErr = moveInterfaceToAnotherNamespace(ifName, curNetNS, clientNetNS, curNetNS); injectErr != nil {
-			goto exit
-		}
-
-		logger.Infof("moved network interface %s into the Forwarder's namespace for connection %s", ifName, conn.GetId())
-	}
-
-exit:
-=======
->>>>>>> 312f205 (add interface rename and inject client chain element)
 	if err != nil && injectErr != nil {
 		return nil, errors.Wrap(err, injectErr.Error())
 	}

--- a/pkg/kernel/networkservice/rename/client.go
+++ b/pkg/kernel/networkservice/rename/client.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2021, Nordix Foundation
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Apache License, Version 2.0
+// which accompanies this distribution, and is available at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package rename
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"google.golang.org/grpc"
+)
+
+type renameClient struct {
+}
+
+// NewClient returns a new link rename client chain element, This client is mostly useful for
+// forwarder's which connects pod container with sriov vf device using VFConfig.
+func NewClient() networkservice.NetworkServiceClient {
+	return &renameClient{}
+}
+
+func (c *renameClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest,
+	opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	logger := log.FromContext(ctx).WithField("renameClient", "Request")
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	mech := kernel.ToMechanism(conn.GetMechanism())
+	if mech == nil {
+		return conn, nil
+	}
+
+	ifName := mech.GetInterfaceName()
+
+	vfConfig := vfconfig.Config(ctx)
+	if vfConfig == nil || vfConfig.VFInterfaceName == ifName {
+		return conn, nil
+	}
+
+	if err := renameLink(vfConfig.VFInterfaceName, ifName); err != nil {
+		return nil, err
+	}
+	logger.Infof("renamed the interface %s into %s", vfConfig.VFInterfaceName, ifName)
+	return conn, nil
+}
+
+func (c *renameClient) Close(ctx context.Context, conn *networkservice.Connection,
+	opts ...grpc.CallOption) (*empty.Empty, error) {
+	logger := log.FromContext(ctx).WithField("renameClient", "Close")
+
+	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
+
+	var renameErr error
+	if mech := kernel.ToMechanism(conn.GetMechanism()); mech != nil {
+		ifName := mech.GetInterfaceName()
+		_, err := netlink.LinkByName(ifName)
+		if err == nil {
+			vfConfig := vfconfig.Config(ctx)
+			renameErr = renameLink(ifName, vfConfig.VFInterfaceName)
+			logger.Infof("renamed interface %s back into original name %s", ifName, vfConfig.VFInterfaceName)
+		}
+	}
+
+	if err != nil && renameErr != nil {
+		return nil, errors.Wrap(err, renameErr.Error())
+	}
+	if renameErr != nil {
+		return nil, renameErr
+	}
+	return rv, nil
+}

--- a/pkg/kernel/networkservice/rename/client.go
+++ b/pkg/kernel/networkservice/rename/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Nordix Foundation.
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -61,6 +61,9 @@ func (c *renameClient) Request(ctx context.Context, request *networkservice.Netw
 	}
 
 	if err := renameLink(vfConfig.VFInterfaceName, ifName); err != nil {
+		if _, closeErr := next.Client(ctx).Close(ctx, conn, opts...); closeErr != nil {
+			logger.Errorf("failed to close failed connection: %s %s", conn.GetId(), closeErr.Error())
+		}
 		return nil, err
 	}
 	logger.Infof("renamed the interface %s into %s", vfConfig.VFInterfaceName, ifName)
@@ -75,13 +78,8 @@ func (c *renameClient) Close(ctx context.Context, conn *networkservice.Connectio
 
 	var renameErr error
 	if mech := kernel.ToMechanism(conn.GetMechanism()); mech != nil {
-<<<<<<< HEAD
 		ifName := mech.GetInterfaceName()
-		_, err := netlink.LinkByName(ifName)
-=======
-		ifName := mech.GetInterfaceName(conn)
 		_, err = netlink.LinkByName(ifName)
->>>>>>> 1a29404 (fix lint issues)
 		if err == nil {
 			vfConfig := vfconfig.Config(ctx)
 			renameErr = renameLink(ifName, vfConfig.VFInterfaceName)

--- a/pkg/kernel/networkservice/rename/client.go
+++ b/pkg/kernel/networkservice/rename/client.go
@@ -1,9 +1,18 @@
-// Copyright (C) 2021, Nordix Foundation
+// Copyright (c) 2020 Nordix Foundation.
 //
-// All rights reserved. This program and the accompanying materials
-// are made available under the terms of the Apache License, Version 2.0
-// which accompanies this distribution, and is available at
-// http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package rename
 
@@ -13,12 +22,13 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
-	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
 )
 
 type renameClient struct {
@@ -65,8 +75,13 @@ func (c *renameClient) Close(ctx context.Context, conn *networkservice.Connectio
 
 	var renameErr error
 	if mech := kernel.ToMechanism(conn.GetMechanism()); mech != nil {
+<<<<<<< HEAD
 		ifName := mech.GetInterfaceName()
 		_, err := netlink.LinkByName(ifName)
+=======
+		ifName := mech.GetInterfaceName(conn)
+		_, err = netlink.LinkByName(ifName)
+>>>>>>> 1a29404 (fix lint issues)
 		if err == nil {
 			vfConfig := vfconfig.Config(ctx)
 			renameErr = renameLink(ifName, vfConfig.VFInterfaceName)

--- a/pkg/kernel/networkservice/rename/common.go
+++ b/pkg/kernel/networkservice/rename/common.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2021, Nordix Foundation
+//
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Apache License, Version 2.0
+// which accompanies this distribution, and is available at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package rename
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+)
+
+func renameLink(oldName, newName string) error {
+	link, err := netlink.LinkByName(oldName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get the net interface: %v", oldName)
+	}
+
+	if err = netlink.LinkSetName(link, newName); err != nil {
+		return errors.Wrapf(err, "failed to rename net interface: %v -> %v", oldName, newName)
+	}
+
+	return nil
+}

--- a/pkg/kernel/networkservice/rename/common.go
+++ b/pkg/kernel/networkservice/rename/common.go
@@ -1,9 +1,18 @@
-// Copyright (C) 2021, Nordix Foundation
+// Copyright (c) 2020 Nordix Foundation.
 //
-// All rights reserved. This program and the accompanying materials
-// are made available under the terms of the Apache License, Version 2.0
-// which accompanies this distribution, and is available at
-// http://www.apache.org/licenses/LICENSE-2.0
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package rename
 

--- a/pkg/kernel/networkservice/rename/common.go
+++ b/pkg/kernel/networkservice/rename/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Nordix Foundation.
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/kernel/networkservice/rename/server.go
+++ b/pkg/kernel/networkservice/rename/server.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/vishvananda/netlink"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
@@ -95,17 +94,4 @@ func (s *renameServer) Close(ctx context.Context, conn *networkservice.Connectio
 		return nil, renameErr
 	}
 	return &empty.Empty{}, err
-}
-
-func renameLink(oldName, newName string) error {
-	link, err := netlink.LinkByName(oldName)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the net interface: %v", oldName)
-	}
-
-	if err = netlink.LinkSetName(link, newName); err != nil {
-		return errors.Wrapf(err, "failed to rename net interface: %v -> %v", oldName, newName)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This commit attempts to provide rename and inject veth or VF interface
facility for endpoint pod container.

Fixes #226 

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>