### PR TITLE
Switch to using GOPRIVATE instead of GOPROXY

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |
-          GOPROXY=direct go get -u github.com/${{ github.repository }}@main
+          GOPRIVATE=github.com/networkservicemesh go get -u github.com/${{ github.repository }}@main
           go mod tidy
           git diff
       - name: Push update to the ${{ matrix.repository }}


### PR DESCRIPTION
Because otherwise we get failures like:

https://github.com/networkservicemesh/sdk-kernel/runs/3214841353?check_suite_focus=true

Which are related to:

https://github.com/influxdata/telegraf/issues/8800

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
