### PR TITLE
make inject chain element idempotent

### DIFF
--- a/pkg/kernel/link.go
+++ b/pkg/kernel/link.go
@@ -158,6 +158,16 @@ func (l *link) SetName(name string) error {
 func FindHostDevice(pciAddress, name string, namespaces ...netns.NsHandle) (Link, error) {
 	// TODO: add support for shared l interfaces (like Mellanox NICs)
 
+	current, err := nshandle.Current()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := netns.Set(current); err != nil {
+			panic(errors.Wrapf(err, "failed to switch back to the current net NS: %v", current).Error())
+		}
+	}()
+
 	attempts := []func(netns.NsHandle, string, string) (netlink.Link, error){
 		searchByPCIAddress,
 		searchByName,

--- a/pkg/kernel/networkservice/inject/common.go
+++ b/pkg/kernel/networkservice/inject/common.go
@@ -17,6 +17,8 @@
 package inject
 
 import (
+	"strings"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -78,7 +80,11 @@ func move(logger log.Logger, conn *networkservice.Connection, isMoveBack bool) e
 		err = moveInterfaceToAnotherNamespace(ifName, curNetNS, targetNetNS, curNetNS)
 	}
 	if err != nil {
-		logger.Warnf("failed to move network interface %s into the target namespace for connection %s", ifName, conn.GetId())
+		logger.Infof("can't move network interface %s into the target namespace for connection %s: %v", ifName, conn.GetId(), err)
+		// link may not be available at this stage (might be deleted in previous chain element itself) for veth case
+		if strings.Contains(err.Error(), "Link not found") {
+			return nil
+		}
 		return err
 	}
 	logger.Infof("moved network interface %s into the target namespace for connection %s", ifName, conn.GetId())


### PR DESCRIPTION
make inject chain element not to throw error when interface is already moved into target net namespace. this can happen when this element can be invoked multiple times due to client refresh requests.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>