### PR TITLE
add sdk-ovs as dependent repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
       matrix:
         repository:
           - sdk-sriov
+          - sdk-ovs
     name: Update ${{ matrix.repository }}
     needs: create-release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -18,6 +18,7 @@ jobs:
         repository:
           - sdk-sriov
           - sdk-vpp
+          - sdk-ovs
     name: Update ${{ matrix.repository }}
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}


### PR DESCRIPTION
for go.mod version updates, this would be useful once this [pr](https://github.com/networkservicemesh/sdk-ovs/pull/1) is merged.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>