### PR TITLE
remove sdk-ovs as dependent repo for sdk-kernel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,6 @@ jobs:
         repository:
           - sdk-sriov
           - sdk-vpp
-          - sdk-ovs
     name: Update ${{ matrix.repository }}
     needs: create-release
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -18,7 +18,6 @@ jobs:
         repository:
           - sdk-sriov
           - sdk-vpp
-          - sdk-ovs
     name: Update ${{ matrix.repository }}
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}


### PR DESCRIPTION
Though `sdk-ovs `repo depends on `sdk-kernel`  and `sdk-sriov` repos, but this dependency is addressed with this [PR](https://github.com/networkservicemesh/sdk-sriov/pull/232) which creates a chain `sdk-kernel -> sdk-sriov -> sdk-ovs` dependency, so there is no need of direct dependency with sdk-kernel.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>