### PR TITLE
keep nse container net ns open until inject connection close is done

### DIFF
--- a/pkg/kernel/networkservice/inject/common.go
+++ b/pkg/kernel/networkservice/inject/common.go
@@ -94,7 +94,13 @@ func move(ctx context.Context, conn *networkservice.Connection, isClient, isMove
 	if !contNetNS.IsOpen() && isMoveBack {
 		contNetNS = vfConfig.ContNetNS
 	}
-	defer func() { _ = contNetNS.Close() }()
+
+	// keep NSE container's net ns open until connection close is done,.
+	// this would properly move back VF into host net namespace even when
+	// container is accidentally deleted before close.
+	if !isClient || isMoveBack {
+		defer func() { _ = contNetNS.Close() }()
+	}
 
 	ifName := mech.GetInterfaceName()
 	if !isMoveBack {

--- a/pkg/kernel/networkservice/vfconfig/metadata.go
+++ b/pkg/kernel/networkservice/vfconfig/metadata.go
@@ -22,6 +22,8 @@ package vfconfig
 import (
 	"context"
 
+	"github.com/vishvananda/netns"
+
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
 
@@ -37,6 +39,8 @@ type VFConfig struct {
 	VFPCIAddress string
 	// VFNum is a VF num for the parent PF
 	VFNum int
+	// ContNetNS is a container netns id on which VF is attached
+	ContNetNS netns.NsHandle
 }
 
 // Store sets the VFConfig stored in per Connection.Id metadata.


### PR DESCRIPTION
This would properly move back VF into host net namespace when NSE pod is deleted prematurely even before forwarder sends service close request.

Fixes #333 