### PR TITLE
[qfix] Fix goroutine leak in ipaddress

### DIFF
--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/ipaddress/common.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/ipaddress/common.go
@@ -139,7 +139,10 @@ func waitForIPNets(ctx context.Context, ch chan netlink.AddrUpdate, l netlink.Li
 		select {
 		case <-ctx.Done():
 			return errors.Wrapf(ctx.Err(), "timeout waiting for update to add ip addresses %s to %s (type: %s)", ipNets, l.Attrs().Name, l.Type())
-		case update := <-ch:
+		case update, ok := <-ch:
+			if !ok {
+				return errors.Errorf("failed to receive update to add ip addresses %s to %s (type: %s)", ipNets, l.Attrs().Name, l.Type())
+			}
 			if update.LinkIndex == l.Attrs().Index {
 				for i := range ipNets {
 					if update.LinkAddress.IP.Equal(ipNets[i].IP) && update.Flags&unix.IFA_F_TENTATIVE == 0 {


### PR DESCRIPTION
## Description
Fully reads channel with input from `netlink.addrSubscribeAt` to fix goroutines leak in `ipaddress`.

## Motivation
`netlink.addrSubscribeAt` does almost the following behavior:
```
go func() {
    defer close(ch)
    for isNotClosed(done) {
        ch <- doSomething()
    }
}()
```
So the error currently is happening is `ch` not fully read after the `close(done)`, so this goroutine blocks on send and cannot return.
```
goroutine profile: total 5185
5146 @ 0x43aa65 0x4059fa 0x405755 0xd22279 0x471c61
#	0xd22278	github.com/vishvananda/netlink.addrSubscribeAt.func2+0x538	/root/go/pkg/mod/github.com/vishvananda/netlink@v1.1.0/addr_linux.go:405
```

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
