### PR TITLE
[qfix] Fix leaking ns handles

### DIFF
--- a/pkg/kernel/link.go
+++ b/pkg/kernel/link.go
@@ -176,6 +176,7 @@ func FindHostDevice(pciAddress, name string, namespaces ...netns.NsHandle) (Link
 		if err := netns.Set(current); err != nil {
 			panic(errors.Wrapf(err, "failed to switch back to the current net NS: %v", current).Error())
 		}
+		_ = current.Close()
 	}()
 
 	attempts := []func(netns.NsHandle, string, string) (netlink.Link, error){
@@ -259,6 +260,7 @@ func GetNetlinkHandle(urlString string) (*netlink.Handle, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	defer func() { _ = curNSHandle.Close() }()
 
 	nsHandle, err := nshandle.FromURL(urlString)
 	if err != nil {


### PR DESCRIPTION
## Description
Fixes leaking NS handles.

## Motivation
Found in https://github.com/networkservicemesh/deployments-k8s/issues/2381#issuecomment-940120379 logs:
[forwarder_old_8.zip](https://github.com/networkservicemesh/deployments-k8s/files/7322924/forwarder_old_8.zip)

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
