### PR TITLE
Fix liveness check

### DIFF
--- a/pkg/kernel/tools/heal/liveness_check.go
+++ b/pkg/kernel/tools/heal/liveness_check.go
@@ -47,7 +47,7 @@ func KernelLivenessCheck(deadlineCtx context.Context, conn *networkservice.Conne
 	}
 
 	addrCount := len(conn.GetContext().GetIpContext().GetDstIpAddrs())
-	timeout := time.Until(deadline) / time.Duration(addrCount+1)
+	timeout := time.Until(deadline) / time.Duration(addrCount)
 
 	var pinger *ping.Pinger
 
@@ -66,6 +66,7 @@ func KernelLivenessCheck(deadlineCtx context.Context, conn *networkservice.Conne
 				return false
 			}
 			pinger.SetPrivileged(true)
+			pinger.Interval = timeout / packetCount
 			pinger.Timeout = timeout
 			pinger.Count = packetCount
 		} else {
@@ -81,11 +82,5 @@ func KernelLivenessCheck(deadlineCtx context.Context, conn *networkservice.Conne
 			return false
 		}
 	}
-
-	select {
-	case <-deadlineCtx.Done():
-		return false
-	default:
-		return true
-	}
+	return true
 }


### PR DESCRIPTION
Motivation:
1. If we add +1 [here](https://github.com/networkservicemesh/sdk-kernel/blob/main/pkg/kernel/tools/heal/liveness_check.go#L50), we unreasonably reduce the timeout (up to 2 times)
2. We cover this [select](https://github.com/networkservicemesh/sdk-kernel/blob/main/pkg/kernel/tools/heal/liveness_check.go#L85-L90) using `pinger.Timeout` [here](https://github.com/networkservicemesh/sdk-kernel/blob/main/pkg/kernel/tools/heal/liveness_check.go#L69)
3. We need to set `pinger.Interval`, because by default it is 1s.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>