### PR TITLE
Data path healing should be disabled

### DIFF
--- a/pkg/kernel/tools/heal/liveness_check.go
+++ b/pkg/kernel/tools/heal/liveness_check.go
@@ -47,6 +47,10 @@ func KernelLivenessCheck(deadlineCtx context.Context, conn *networkservice.Conne
 	}
 
 	addrCount := len(conn.GetContext().GetIpContext().GetDstIpAddrs())
+	if addrCount == 0 {
+		log.FromContext(deadlineCtx).Debug("No dst IP address")
+		return true
+	}
 	timeout := time.Until(deadline) / time.Duration(addrCount)
 
 	var pinger *ping.Pinger


### PR DESCRIPTION
Related issue: networkservicemesh/cmd-nsc#447

Return from LivenessCheck if no dst addresses set in the context

Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>