### PR TITLE
Improve resiliency on ip context policy routes

### DIFF
--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2021-2022 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package iprule
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+
+	link "github.com/networkservicemesh/sdk-kernel/pkg/kernel"
+)
+
+func recoverTableIDs(ctx context.Context, conn *networkservice.Connection, tableIDs *Map) error {
+	if mechanism := kernel.ToMechanism(conn.GetMechanism()); mechanism != nil && mechanism.GetVLAN() == 0 {
+		netlinkHandle, err := link.GetNetlinkHandle(mechanism.GetNetNSURL())
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer netlinkHandle.Close()
+
+		podRules, err := netlinkHandle.RuleList(netlink.FAMILY_ALL)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		ps, ok := tableIDs.Load(conn.GetId())
+		if !ok {
+			if len(conn.Context.IpContext.Policies) == 0 {
+				return nil
+			}
+			ps = make(map[int]*networkservice.PolicyRoute)
+			tableIDs.Store(conn.GetId(), ps)
+		}
+
+		// Get policies to add and to remove
+		missingPolicies, _ := getPolicyDifferences(ps, conn.Context.IpContext.Policies)
+
+		// try to find the corresponding missing policies in the network namespace of the pod
+		for _, policy := range missingPolicies {
+			policyRule, err := policyToRule(policy)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			for i := range podRules {
+				if ruleEquals(&podRules[i], policyRule) {
+					log.FromContext(ctx).
+						WithField("From", policy.From).
+						WithField("IPProto", policy.Proto).
+						WithField("DstPort", policy.DstPort).
+						WithField("SrcPort", policy.SrcPort).
+						WithField("Table", podRules[i].Table).Debug("policy recovered")
+					ps[podRules[i].Table] = policy
+					tableIDs.Store(conn.GetId(), ps)
+					break
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func ruleEquals(a, b *netlink.Rule) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Src.String() == b.Src.String() && a.IPProto == b.IPProto && rulePortRangeEquals(a.Dport, b.Dport) && rulePortRangeEquals(a.Sport, b.Sport)
+}
+
+func rulePortRangeEquals(a, b *netlink.RulePortRange) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Start == b.Start && a.End == b.End
+}

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/server.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/server.go
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2021-2022 Nordix Foundation.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +46,11 @@ func (i *ipruleServer) Request(ctx context.Context, request *networkservice.Netw
 	postponeCtxFunc := postpone.ContextWithValues(ctx)
 
 	conn, err := next.Server(ctx).Request(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	err = recoverTableIDs(ctx, conn, &i.tables)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When a forwarder was restarting, the handled table IDs by the forwarded
were forgotten which caused duplicated tables/rules/routes in the pod
and potentially left routes which could cause traffic disturbances in
some cases.

Now, the forwarder is checking if the tables which exist in the pod are
corresponding to the requested policies before creating any other ones.
In case such tables exist, the forwarder will consider it as its own
table.

https://github.com/networkservicemesh/sdk-kernel/issues/426