### PR TITLE
Use livelinesschecker in non-privileged mode

### DIFF
--- a/pkg/kernel/networkservice/pinggrouprange/client.go
+++ b/pkg/kernel/networkservice/pinggrouprange/client.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pinggrouprange
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
+)
+
+type pinggrouprangeClient struct{}
+
+// NewClient provides a NetworkServiceClient that sets the ping_group_range on the NSE
+func NewClient() networkservice.NetworkServiceClient {
+	return &pinggrouprangeClient{}
+}
+
+func (p *pinggrouprangeClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	postponeCtxFunc := postpone.ContextWithValues(ctx)
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := set(ctx, conn); err != nil {
+		closeCtx, cancelClose := postponeCtxFunc()
+		defer cancelClose()
+
+		if _, closeErr := p.Close(closeCtx, conn, opts...); closeErr != nil {
+			err = errors.Wrapf(err, "connection closed with error: %s", closeErr.Error())
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (p *pinggrouprangeClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}

--- a/pkg/kernel/networkservice/pinggrouprange/common.go
+++ b/pkg/kernel/networkservice/pinggrouprange/common.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pinggrouprange
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netns"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/tools/nshandle"
+)
+
+// See https://github.com/go-ping/ping#linux
+const groupRange = "0 2147483647"
+
+func set(ctx context.Context, conn *networkservice.Connection) error {
+	if mechanism := kernel.ToMechanism(conn.GetMechanism()); mechanism != nil && mechanism.GetVLAN() == 0 {
+		forwarderNetNS, err := nshandle.Current()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = forwarderNetNS.Close() }()
+
+		var targetNetNS netns.NsHandle
+		targetNetNS, err = nshandle.FromURL(mechanism.GetNetNSURL())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = targetNetNS.Close() }()
+
+		pingGroupRangeFilename := "/proc/sys/net/ipv4/ping_group_range"
+		if err = nshandle.RunIn(forwarderNetNS, targetNetNS, func() error {
+			return ioutil.WriteFile(pingGroupRangeFilename, []byte(groupRange), 0o600)
+		}); err != nil {
+			return errors.Wrapf(err, "failed to set %s = %s", pingGroupRangeFilename, groupRange)
+		}
+		log.FromContext(ctx).Infof("%s was set to %s", pingGroupRangeFilename, groupRange)
+	}
+	return nil
+}

--- a/pkg/kernel/networkservice/pinggrouprange/doc.go
+++ b/pkg/kernel/networkservice/pinggrouprange/doc.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pinggrouprange sets /proc/sys/net/ipv4/ping_group_range variable
+//
+// We use ping to check the liveliness of the connection. In order not to use the root privileges, we need to set the
+// ping_group_range value. It allows to create the SOCK_DGRAM socket type (instead of SOCK_RAW) for ping and thus use it
+// in non-privileged mode.
+// See:
+// https://github.com/go-ping/ping
+// https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
+package pinggrouprange

--- a/pkg/kernel/networkservice/pinggrouprange/server.go
+++ b/pkg/kernel/networkservice/pinggrouprange/server.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pinggrouprange
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
+)
+
+type pinggrouprangeServer struct{}
+
+// NewServer provides a NetworkServiceServer that sets the ping_group_range on the NSC
+func NewServer() networkservice.NetworkServiceServer {
+	return &pinggrouprangeServer{}
+}
+
+func (p *pinggrouprangeServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	postponeCtxFunc := postpone.ContextWithValues(ctx)
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := set(ctx, conn); err != nil {
+		closeCtx, cancelClose := postponeCtxFunc()
+		defer cancelClose()
+
+		if _, closeErr := p.Close(closeCtx, conn); closeErr != nil {
+			err = errors.Wrapf(err, "connection closed with error: %s", closeErr.Error())
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (p *pinggrouprangeServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
+}

--- a/pkg/kernel/tools/heal/liveness_check.go
+++ b/pkg/kernel/tools/heal/liveness_check.go
@@ -152,7 +152,6 @@ type defaultPingerFactory struct{}
 
 func (p *defaultPingerFactory) CreatePinger(srcIP, dstIP string, timeout time.Duration, count int) Pinger {
 	pi := ping.New(dstIP)
-	pi.SetPrivileged(true)
 	pi.Source = srcIP
 	pi.Timeout = timeout
 	pi.Count = count


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/9218

## Description
We use ping to check the liveliness of the connection. In order not to use the root privileges, we need to set the `/proc/sys/net/ipv4/ping_group_range` value. It allows to create the `SOCK_DGRAM` socket type (instead of `SOCK_RAW`) for ping and thus use it in non-privileged mode.