### PR TITLE
Fix work with nsRTableNextIDToConnID

### DIFF
--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/nsrtnextid.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/nsrtnextid.go
@@ -16,15 +16,15 @@
 
 package iprule
 
-// NetnsRTableNextID stores Network namespace and Next Routing Table ID
-type NetnsRTableNextID struct {
+// netnsRTableNextID stores Network namespace and Next Routing Table ID
+type netnsRTableNextID struct {
 	ns    string
 	nrtid int
 }
 
-// NewNetnsRTableNextID returns *NetnsRTableNextID entry
-func NewNetnsRTableNextID(ns string, nrtid int) *NetnsRTableNextID {
-	return &NetnsRTableNextID{
+// createNetnsRTableNextID returns netnsRTableNextID entry
+func createNetnsRTableNextID(ns string, nrtid int) netnsRTableNextID {
+	return netnsRTableNextID{
 		ns:    ns,
 		nrtid: nrtid,
 	}

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/server.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/server.go
@@ -19,7 +19,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 package iprule
 
@@ -41,14 +40,14 @@ type ipruleServer struct {
 	// Protecting route and rule setting with this sync.Map
 	// The next table ID is calculated based on a dump
 	// other connection from same client can add new table in parallel
-	nsRTableNextIDToConnID *genericsync.Map[NetnsRTableNextID, string]
+	nsRTableNextIDToConnID *genericsync.Map[netnsRTableNextID, string]
 }
 
 // NewServer creates a new server chain element setting ip rules
 func NewServer() networkservice.NetworkServiceServer {
 	return &ipruleServer{
 		tables:                 new(genericsync.Map[string, policies]),
-		nsRTableNextIDToConnID: new(genericsync.Map[NetnsRTableNextID, string]),
+		nsRTableNextIDToConnID: new(genericsync.Map[netnsRTableNextID, string]),
 	}
 }
 
@@ -60,7 +59,7 @@ func (i *ipruleServer) Request(ctx context.Context, request *networkservice.Netw
 		return nil, err
 	}
 
-	err = recoverTableIDs(ctx, conn, i.tables)
+	err = recoverTableIDs(ctx, conn, i.tables, i.nsRTableNextIDToConnID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

Alternative fix for https://github.com/networkservicemesh/sdk-kernel/pull/603

### Description

`nsRTableNextIDToConnID` map is used as _**"mutex"**_ for a specific table ID within the netns of one client. 
How it works now (simplistically):
1. tableID = getFreeTableID()
2. nsRTableNextIDToConnID.Store(tableID)
3. Call `addPolicy` - it deletes the entry from the `nsRTableNextIDToConnID` after execution.

In these steps we can get the race condition. If several requests received `tableID=5` in the first step, then one of the requests added rules and cleared the map, then other requests also have a chance to use the same table ID.

I think we should clear `nsRTableNextIDToConnID` only after [flushing a table](https://github.com/networkservicemesh/sdk-kernel/blob/main/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/common.go#L339-L341)
