### PR TITLE
Fix Missing Policy Routes

### DIFF
--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
@@ -57,12 +57,12 @@ func recoverTableIDs(ctx context.Context, conn *networkservice.Connection, table
 		ifName := mechanism.GetInterfaceName()
 		l, err := netlinkHandle.LinkByName(ifName)
 		if err != nil {
-			return errors.Wrapf(err, "failed to find link %s", ifName)
+			return errors.Wrapf(err, "iprule: failed to recover table IDs for interface: %s", ifName)
 		}
 
 		podRules, err := netlinkHandle.RuleList(netlink.FAMILY_ALL)
 		if err != nil {
-			return errors.Wrap(err, "failed to get list of rules")
+			return errors.Wrapf(err, "iprule: failed to recover table IDs in namespace: %s", mechanism.GetNetNSURL())
 		}
 
 		tableIDtoPolicyMap := make(map[int]*networkservice.PolicyRoute)

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2022 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2021-2022 Nordix Foundation.
-//
 // Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// Copyright (c) 2021-2024 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-kernel/issues/685
    
Try to delete the rule even if the route deletion fails.
For example when the belonging interface is deleted in parallel.
