### PR TITLE
Disable automerge workflow for dependabot

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -8,7 +8,7 @@ on:
       - 'ci'
 jobs:
   automerge:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.actor == 'nsmbot' || github.actor == 'dependabot[bot]')}}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' }}
     uses: networkservicemesh/.github/.github/workflows/automerge.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR disables the automerge workflow for pull requests opened by dependabot.