### PR TITLE
Close net NS handles in iprule and netlink handle in FindHostDevice

### DIFF
--- a/pkg/kernel/link.go
+++ b/pkg/kernel/link.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2020-2022 Intel Corporation. All Rights Reserved.
 //
-// Copyright (c) 2021-2022 Nordix Foundation.
-//
 // Copyright (c) 2022-2024 Cisco and/or its affiliates.
+//
+// Copyright (c) 2021-2026 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -271,6 +271,7 @@ func searchByName(ns netns.NsHandle, name, _ string) (netlink.Link, error) {
 	if err != nil {
 		return nil, errors.Errorf("failed to create netlink handler: %s", err)
 	}
+	defer handle.Close()
 
 	// get link
 	link, err := handle.LinkByName(name)

--- a/pkg/kernel/link_fd_leak_perm_test.go
+++ b/pkg/kernel/link_fd_leak_perm_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build perm && linux
+
+package kernel
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+const (
+	testIfName    = "nsmtest0"
+	testIterCount = 25
+)
+
+// countSocketFDs returns the number of file descriptors of the current process
+// that point at a socket (the `socket:[inode]` links under /proc/self/fd).
+// A netlink handle holds one socket per netlink family.
+func countSocketFDs(t *testing.T) int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+
+	var count int
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err != nil {
+			// fd was closed while we were walking the directory
+			continue
+		}
+		if strings.HasPrefix(target, "socket:[") {
+			count++
+		}
+	}
+	return count
+}
+
+// newNetNSWithLink creates a fresh net NS holding a single dummy interface,
+// emulating the net NS FindHostDevice searches in.
+func newNetNSWithLink(t *testing.T) netns.NsHandle {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	baseHandle, err := netns.Get()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, netns.Set(baseHandle))
+		_ = baseHandle.Close()
+	}()
+
+	targetHandle, err := netns.New()
+	require.NoError(t, err)
+
+	handle, err := netlink.NewHandleAt(targetHandle)
+	require.NoError(t, err)
+	defer handle.Close()
+
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: testIfName}}
+	require.NoError(t, handle.LinkAdd(dummy))
+
+	return targetHandle
+}
+
+// TestFindHostDeviceFDLeakPerm - FindHostDevice() must not leak the netlink
+// handle it creates while searching for the interface by name. The inject chain
+// element calls it on every Request and Close, so a leaked handle per call
+// accumulates netlink sockets, and each of them keeps a reference to the net NS
+// it was opened in.
+func TestFindHostDeviceFDLeakPerm(t *testing.T) {
+	targetNetNS := newNetNSWithLink(t)
+	defer func() { _ = targetNetNS.Close() }()
+
+	// Warm up, so that lazily initialized state is not counted as a leak.
+	l, err := FindHostDevice("", testIfName, targetNetNS)
+	require.NoError(t, err)
+	require.Equal(t, testIfName, l.GetName())
+
+	fdsBefore := countSocketFDs(t)
+
+	for i := 0; i < testIterCount; i++ {
+		l, err = FindHostDevice("", testIfName, targetNetNS)
+		require.NoError(t, err)
+		require.Equal(t, testIfName, l.GetName())
+	}
+
+	fdsAfter := countSocketFDs(t)
+	require.Equal(t, fdsBefore, fdsAfter,
+		"FindHostDevice() leaked %d socket fd(s) over %d calls", fdsAfter-fdsBefore, testIterCount)
+}

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/common.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/common.go
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
-// Copyright (c) 2023-2024 Nordix Foundation.
+// Copyright (c) 2023-2026 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -73,6 +73,7 @@ func create(ctx context.Context, conn *networkservice.Connection, tableIDs *gene
 		if err != nil {
 			return errors.Wrapf(err, "iprule: failed to create policy rules in namespace: %s", mechanism.GetNetNSURL())
 		}
+		defer func() { _ = netNS.Close() }()
 
 		// Get policies to add and to remove
 		toAdd, toRemove := getPolicyDifferences(ps, conn.Context.IpContext.Policies)
@@ -293,6 +294,7 @@ func del(ctx context.Context, conn *networkservice.Connection, tableIDs *generic
 			if err != nil {
 				return errors.Wrapf(err, "iprule: failed to delete policy rules in namespace: %s", mechanism.GetNetNSURL())
 			}
+			defer func() { _ = netNS.Close() }()
 			for tableID, policy := range ps {
 				if err := delRule(ctx, netlinkHandle, policy, tableID, l.Attrs().Index, createNetnsRTableNextID(netNS.UniqueId(), tableID), nsRTableNextIDToConnID); err != nil {
 					return err

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/fd_leak_perm_test.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/fd_leak_perm_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build perm && linux
+
+package iprule
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+)
+
+const (
+	testIfName    = "nsmtest0"
+	testConnID    = "conn-1"
+	testIterCount = 25
+)
+
+// countNetNSFDs returns the number of file descriptors of the current process
+// that point at a network namespace (the `net:[inode]` links under /proc/self/fd).
+func countNetNSFDs(t *testing.T) int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+
+	var count int
+	for _, entry := range entries {
+		target, err := os.Readlink(filepath.Join("/proc/self/fd", entry.Name()))
+		if err != nil {
+			// fd was closed while we were walking the directory
+			continue
+		}
+		if strings.HasPrefix(target, "net:[") {
+			count++
+		}
+	}
+	return count
+}
+
+// newTargetNetNS creates a fresh net NS, emulating the net NS of a client pod.
+func newTargetNetNS(t *testing.T) netns.NsHandle {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	baseHandle, err := netns.Get()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, netns.Set(baseHandle))
+		_ = baseHandle.Close()
+	}()
+
+	targetHandle, err := netns.New()
+	require.NoError(t, err)
+
+	return targetHandle
+}
+
+// newTestConn returns a connection with a kernel mechanism pointing at the given
+// net NS and a single policy route, and creates the interface the policy applies to.
+//
+// The net NS is addressed as file:///proc/${pid}/fd/${fd}, which is the form the
+// NSM forwarder receives from the NSC.
+func newTestConn(t *testing.T, targetNetNS netns.NsHandle) *networkservice.Connection {
+	handle, err := netlink.NewHandleAt(targetNetNS)
+	require.NoError(t, err)
+	defer handle.Close()
+
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: testIfName}}
+	require.NoError(t, handle.LinkAdd(dummy))
+	require.NoError(t, handle.LinkSetUp(dummy))
+
+	return &networkservice.Connection{
+		Id: testConnID,
+		Mechanism: &networkservice.Mechanism{
+			Cls:  cls.LOCAL,
+			Type: kernelmech.MECHANISM,
+			Parameters: map[string]string{
+				kernelmech.NetNSURL:         fmt.Sprintf("file:///proc/%d/fd/%d", os.Getpid(), int(targetNetNS)),
+				kernelmech.InterfaceNameKey: testIfName,
+			},
+		},
+		Context: &networkservice.ConnectionContext{
+			IpContext: &networkservice.IPContext{
+				Policies: []*networkservice.PolicyRoute{
+					{
+						From:    "10.0.0.1/32",
+						DstPort: "8080",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestIPRuleFDLeakOnRefreshPerm - create() must not leak a net NS fd per Request.
+// create() is called on every Request, including every refresh of an established
+// connection, so a single leaked fd per call exhausts the forwarder's fd limit.
+func TestIPRuleFDLeakOnRefreshPerm(t *testing.T) {
+	targetNetNS := newTargetNetNS(t)
+	defer func() { _ = targetNetNS.Close() }()
+
+	conn := newTestConn(t, targetNetNS)
+	tableIDs := new(genericsync.Map[string, policies])
+	nsRTableNextIDToConnID := new(genericsync.Map[netnsRTableNextID, string])
+
+	// First Request - installs the policy and any long lived state.
+	require.NoError(t, create(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+
+	fdsBefore := countNetNSFDs(t)
+
+	// Refreshes - nothing to add or remove, but the net NS is opened every time.
+	for i := 0; i < testIterCount; i++ {
+		require.NoError(t, create(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+	}
+
+	fdsAfter := countNetNSFDs(t)
+	require.Equal(t, fdsBefore, fdsAfter,
+		"create() leaked %d net NS fd(s) over %d refreshes", fdsAfter-fdsBefore, testIterCount)
+}
+
+// TestIPRuleFDLeakOnClosePerm - del() must not leak a net NS fd per Close.
+func TestIPRuleFDLeakOnClosePerm(t *testing.T) {
+	targetNetNS := newTargetNetNS(t)
+	defer func() { _ = targetNetNS.Close() }()
+
+	conn := newTestConn(t, targetNetNS)
+	tableIDs := new(genericsync.Map[string, policies])
+	nsRTableNextIDToConnID := new(genericsync.Map[netnsRTableNextID, string])
+
+	// Warm up one full cycle.
+	require.NoError(t, create(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+	require.NoError(t, del(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+
+	fdsBefore := countNetNSFDs(t)
+
+	for i := 0; i < testIterCount; i++ {
+		require.NoError(t, create(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+		require.NoError(t, del(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+	}
+
+	fdsAfter := countNetNSFDs(t)
+	require.Equal(t, fdsBefore, fdsAfter,
+		"create()/del() leaked %d net NS fd(s) over %d cycles", fdsAfter-fdsBefore, testIterCount)
+}
+
+// TestIPRuleFDLeakOnRecoverPerm - recoverTableIDs()/deleteRemainders() must not
+// leak a net NS fd. This path is taken on the first Request after a forwarder
+// restart, and on every Request for a connection whose table IDs are not cached.
+func TestIPRuleFDLeakOnRecoverPerm(t *testing.T) {
+	targetNetNS := newTargetNetNS(t)
+	defer func() { _ = targetNetNS.Close() }()
+
+	conn := newTestConn(t, targetNetNS)
+	tableIDs := new(genericsync.Map[string, policies])
+	nsRTableNextIDToConnID := new(genericsync.Map[netnsRTableNextID, string])
+
+	require.NoError(t, create(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+	// Drop the cache, so the next Request has to recover the table IDs.
+	tableIDs.Delete(testConnID)
+	require.NoError(t, recoverTableIDs(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+
+	fdsBefore := countNetNSFDs(t)
+
+	for i := 0; i < testIterCount; i++ {
+		tableIDs.Delete(testConnID)
+		require.NoError(t, recoverTableIDs(context.Background(), conn, tableIDs, nsRTableNextIDToConnID))
+	}
+
+	fdsAfter := countNetNSFDs(t)
+	require.Equal(t, fdsBefore, fdsAfter,
+		"recoverTableIDs() leaked %d net NS fd(s) over %d calls", fdsAfter-fdsBefore, testIterCount)
+}

--- a/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
+++ b/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule/heal.go
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
-// Copyright (c) 2021-2024 Nordix Foundation.
+// Copyright (c) 2021-2026 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -97,6 +97,7 @@ func deleteRemainders(ctx context.Context, netlinkHandle *netlink.Handle, tableI
 	if err != nil {
 		return err
 	}
+	defer func() { _ = netNS.Close() }()
 	for tableID, policy := range tableIDtoPolicyMap {
 		usage := 0
 		for i := range podRules {


### PR DESCRIPTION
## Issue

`forwarder-vpp` leaks one file descriptor pointing at the client pod's network namespace on every `Request` for a connection whose `IpContext` carries policies.

`nshandle.FromURL()` returns the net NS as an fd (`netns.GetFromPath`), but in `pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule` the handle is only used for `netNS.UniqueId()` and never closed. There are three such call sites:

| Function | File | Called on |
| --- | --- | --- |
| `create()` | `common.go` | every `Request`, including every refresh of an established connection |
| `del()` | `common.go` | every `Close` |
| `deleteRemainders()` | `heal.go` | every recovery of table IDs (e.g. first `Request` after a forwarder restart) |

`ipruleServer.Request()` calls `recoverTableIDs()` and then `create()` unconditionally, so no state change is needed for the leak to grow — a connection that is merely being refreshed leaks one fd per refresh, for the lifetime of the forwarder.

Since `create()` returns early when there are neither cached table IDs nor policies, only connections carrying `IpContext.Policies` are affected.

## Impact

Beyond the fd count itself, every leaked fd keeps the client pod's network namespace alive. `del()` closes at most one handle (and leaks another), so the handles accumulated by refreshes survive connection teardown: after the client pod is deleted its net NS cannot be released until the forwarder restarts. On a long lived node with pod churn this accumulates dead namespaces and their interfaces.

## Observed in a live deployment

Found with `forwarder-vpp` v1.14.4 (`sdk-kernel@v1.14.4`) in a 4 node cluster running Meridio, whose TAPA sets policy routes derived from the VIPs. Per forwarder, the fd count on exactly one net NS grew monotonically:


forwarder-vpp-g2ngs (pid 7505) - 36
       18 net:[4026536538]     <- target pod net NS, growing
        8 net:[4026534822]     <- stateless-lb pod net NS, flat
        6 net:[4026535797]     <- proxy pod net NS, flat
        4 net:[4026534204]     <- host net NS, flat

`net:[4026536538]` is the net NS of the connection whose mechanism is `inode://5/4026536538` and whose `IpContext` contains `policies`. After 22 `Request`s for that connection the forwarder held 24 fds on its net NS. The connections without policies were flat the whole time, which is consistent with the early return in `create()`.

The same fd growth can be observed directly on a node:

```bash
pid=$(pidof forwarder)
ls -l /proc/$pid/fd | grep -o "net:\[[0-9]*\]" | sort | uniq -c | sort -rn
```

## Second leak: `FindHostDevice()`

While reading the same package: `searchByName()` in `pkg/kernel/link.go` creates a netlink handle with `netlink.NewHandleAt()` and never closes it. `netlink.NewHandleAt` with no explicit families opens one socket per supported family, so each call leaks 3 socket fds, and each socket holds a reference to the net NS it was created in. `FindHostDevice()` is reached from the `inject` chain element on both `Request` and `Close`.

Closing the handle is safe: the returned `netlink.Link` is plain attribute data, and the `link` methods (`SetAdminState`, `SetName`, `AddAddress`, ...) all use the package level `netlink` functions rather than this handle.

## Fix

Four `Close()` calls:

- `iprule/common.go`: `defer func() { _ = netNS.Close() }()` in `create()` and `del()`
- `iprule/heal.go`: same in `deleteRemainders()`
- `pkg/kernel/link.go`: `defer handle.Close()` in `searchByName()`

## Tests

Two new `perm` tagged test files that count the process' own `net:[...]` / `socket:[...]` fds around repeated calls, so they run in CI via the existing `Test with permissions` step (`go test -race -run Perm ./... -tags=perm`):

- `iprule/fd_leak_perm_test.go` — `create()` over refreshes, `create()`/`del()` cycles, and `recoverTableIDs()`
- `pkg/kernel/link_fd_leak_perm_test.go` — `FindHostDevice()` over repeated lookups

Without the fix:

```bash
FAIL: TestIPRuleFDLeakOnRefreshPerm  create() leaked 25 net NS fd(s) over 25 refreshes
FAIL: TestIPRuleFDLeakOnClosePerm    create()/del() leaked 50 net NS fd(s) over 25 cycles
FAIL: TestIPRuleFDLeakOnRecoverPerm  recoverTableIDs() leaked 25 net NS fd(s) over 25 calls
FAIL: TestFindHostDeviceFDLeakPerm   FindHostDevice() leaked 75 socket fd(s) over 25 calls
```

With the fix:

```bash
ok  github.com/networkservicemesh/sdk-kernel/pkg/kernel
ok  github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/connectioncontextkernel/ipcontext/iprule
```

The 50 in the second case is `create()` plus `del()` per cycle, confirming the two sites leak independently.

`go build ./...`, `go vet ./...`, `golangci-lint run` and `golangci-lint run --build-tags perm` are clean. Copyright years bumped where `goheader` requires it.